### PR TITLE
Fixed issue when parsing NPM packages, where in some instance the had…

### DIFF
--- a/IT.TFM/NpmFileParser/PackageParser.cs
+++ b/IT.TFM/NpmFileParser/PackageParser.cs
@@ -36,10 +36,12 @@ namespace NpmFileParser
             while (dependency != null)
             {
                 var dependencyString = dependency.ToString();
-                var cleanDependency = dependencyString.Replace("\"", string.Empty);
+                var cleanDependency = dependencyString.Replace("\"", string.Empty)
+                                                      .Replace(@"://", "-");
                 var fields = cleanDependency.Split(new char[] { ':' });
                 if (fields.Count() != 2)
                 {
+                    dependency = dependency.Next;
                     continue;
                 }
 


### PR DESCRIPTION
NPM package parsing failed when the package contains a git:// url, and the : was causing the parsing to fail.  Fixed by replacing :// with dash (-).