### PR TITLE
Feature/no scan

### DIFF
--- a/IT.TFM/DataModels/IWriteRepoList.cs
+++ b/IT.TFM/DataModels/IWriteRepoList.cs
@@ -2,6 +2,6 @@
 {
     public interface IWriteRepoList
     {
-        void Write(RepositoryItem item);
+        void Write(RepositoryItem item, bool repoOnly);
     }
 }

--- a/IT.TFM/DataModels/RepositoryItem.cs
+++ b/IT.TFM/DataModels/RepositoryItem.cs
@@ -39,6 +39,8 @@ namespace RepoScan.DataModels
 
         public bool ProjectIsDeleted { get; set; }
 
+        public bool ProjectNoScan { get; set; } = false;
+
         public Guid RepositoryId { get; set; }
 
         public string RepositoryName { get; set; }
@@ -60,5 +62,7 @@ namespace RepoScan.DataModels
         public string RepositoryLastCommitId { get; set; }
 
         public bool IsDeleted { get; set; }
+
+        public bool RepositoryNoScan { get; set; } = false;
     }
 }

--- a/IT.TFM/FileLocator/FileDetails.cs
+++ b/IT.TFM/FileLocator/FileDetails.cs
@@ -29,6 +29,12 @@ namespace RepoScan.FileLocator
             IReadRepoList repoReader = StorageFactory.GetRepoListReader();
             foreach (var repoItem in repoReader.Read())
             {
+                // Skip any repos that have been flagged as deleted or No Scan
+                if (repoItem.ProjectNoScan || repoItem.ProjectIsDeleted || repoItem.RepositoryNoScan || repoItem.IsDeleted)
+                {
+                    continue;
+                }
+
                 var errorMsg = string.Empty;
                 bool hasError = false;
 

--- a/IT.TFM/FileLocator/FileProcessor.cs
+++ b/IT.TFM/FileLocator/FileProcessor.cs
@@ -37,8 +37,8 @@ namespace RepoScan.FileLocator
 
             foreach (var repoItem in reader.Read())
             {
-                // Skip any repos that have been flagged as deleted
-                if (repoItem.ProjectIsDeleted || repoItem.IsDeleted)
+                // Skip any repos that have been flagged as deleted or No Scan
+                if (repoItem.ProjectNoScan || repoItem.ProjectIsDeleted || repoItem.RepositoryNoScan || repoItem.IsDeleted)
                 {
                     continue;
                 }
@@ -60,7 +60,7 @@ namespace RepoScan.FileLocator
                 if (!projectList.Any(p => p == repoItem.ProjectId))
                 {
                     repoItem.ProjectIsDeleted = true;
-                    repoWriter.Write(repoItem);
+                    repoWriter.Write(repoItem, false);
 
                     continue;
                 }
@@ -100,7 +100,7 @@ namespace RepoScan.FileLocator
                 {
                     // flag repo as deleted.
                     repoItem.IsDeleted = true;
-                    repoWriter.Write(repoItem);
+                    repoWriter.Write(repoItem, false);
 
                     continue;
                 }
@@ -110,7 +110,7 @@ namespace RepoScan.FileLocator
                     continue;
                 }
 
-                repoWriter.Write(repoItem);
+                repoWriter.Write(repoItem, false);
 
                 var repo = new Repository
                 {

--- a/IT.TFM/FileLocator/Scanner.cs
+++ b/IT.TFM/FileLocator/Scanner.cs
@@ -25,6 +25,7 @@ namespace RepoScan.FileLocator
             IWriteRepoList writer = StorageFactory.GetRepoListWriter();
 
             Settings.Initialize();
+
             foreach (var name in Settings.Scanners)
             {
                 var scanner = ScannerFactory.GetScanner(name);
@@ -32,6 +33,8 @@ namespace RepoScan.FileLocator
                 var organization = scanner.GetOrganization();
                 await foreach (var project in scanner.Projects())
                 {
+                    bool repoOnly = false;
+
                     var repos = await scanner.Repositories(project);
 
                     foreach (var repo in repos)
@@ -64,7 +67,10 @@ namespace RepoScan.FileLocator
                         };
 
                         // Write repo item to queue
-                        writer.Write(repoItem);
+                        // TODO: change this to include a flag, indicating only writing the repo.
+                        // Otherwise we are re-writing the Org and Project with the same data for each repo
+                        writer.Write(repoItem, repoOnly);
+                        repoOnly = true;
                     }
                 }
             }

--- a/IT.TFM/ProjectDataFramework/Project.cs
+++ b/IT.TFM/ProjectDataFramework/Project.cs
@@ -46,6 +46,8 @@ namespace ProjectData
 
         public bool Deleted { get; set; }
 
+        public bool NoScan { get; set; }
+
         public IEnumerable<Repository> Repositories
         {
             get { return repositories.AsEnumerable(); }

--- a/IT.TFM/ProjectDataFramework/Repository.cs
+++ b/IT.TFM/ProjectDataFramework/Repository.cs
@@ -43,6 +43,8 @@ namespace ProjectData
 
         public string LastCommitId { get; set; }
 
+        public bool NoScan { get; set; }
+
         #endregion
 
         #region Public Methods

--- a/IT.TFM/ProjectScannerDB/dbo/Tables/Projects.sql
+++ b/IT.TFM/ProjectScannerDB/dbo/Tables/Projects.sql
@@ -12,6 +12,7 @@
     [Url] NVARCHAR(MAX) NOT NULL, 
     [Visibility] NVARCHAR(50) NULL, 
     [Deleted] BIT NOT NULL DEFAULT 0, 
+    [NoScan] BIT NOT NULL DEFAULT 0, 
     CONSTRAINT [PK_Projects] PRIMARY KEY ([Id]), 
     CONSTRAINT [FK_Projects_ToOrganization] FOREIGN KEY ([OrganizationId]) REFERENCES [dbo].[Organizations]([Id]),
 )

--- a/IT.TFM/ProjectScannerDB/dbo/Tables/Repositories.sql
+++ b/IT.TFM/ProjectScannerDB/dbo/Tables/Repositories.sql
@@ -16,6 +16,7 @@
     [Deleted] BIT NOT NULL DEFAULT 0,
     [LastCommitId] NVARCHAR(50) NULL DEFAULT '', 
     [TooBig] BIT NOT NULL DEFAULT 0, 
+    [NoScan] BIT NOT NULL DEFAULT 0, 
     CONSTRAINT [PK_Repositories] PRIMARY KEY ([Id]), 
     CONSTRAINT [FK_Repositories_ToProject] FOREIGN KEY ([ProjectId]) REFERENCES [dbo].[Projects]([Id])
 )

--- a/IT.TFM/ProjectScannerSaveToSqlServer/DataModels/Project.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/DataModels/Project.cs
@@ -45,6 +45,8 @@ namespace ProjectScannerSaveToSqlServer.DataModels
 
         public bool Deleted { get; set; }
 
+        public bool NoScan { get; set; }
+
         public virtual Organization Organization { get; set; }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/IT.TFM/ProjectScannerSaveToSqlServer/DataModels/Repository.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/DataModels/Repository.cs
@@ -43,6 +43,8 @@ namespace ProjectScannerSaveToSqlServer.DataModels
 
         public bool Deleted { get; set; }
 
+        public bool NoScan { get; set; }
+
         [StringLength(50)]
         public string LastCommitId { get; set; }
 

--- a/IT.TFM/ProjectScannerSaveToSqlServer/Read.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/Read.cs
@@ -46,7 +46,7 @@ namespace ProjectScannerSaveToSqlServer
 
             foreach(var dbProject in dbOrganization.Projects)
             {
-                var project = new Project
+                var dataProject = new Project
                 {
                     Id = new Guid(dbProject.ProjectId),
                     Name = dbProject.Name,
@@ -57,7 +57,8 @@ namespace ProjectScannerSaveToSqlServer
                     State = dbProject.State,
                     Url = dbProject.Url,
                     Visibility = dbProject.Visibility,
-                    Deleted = dbProject.Deleted
+                    Deleted = dbProject.Deleted,
+                    NoScan = dbProject.NoScan
                 };
 
                 foreach (var repo in dbProject.Repositories)
@@ -74,13 +75,14 @@ namespace ProjectScannerSaveToSqlServer
                         Url = repo.Url,
                         WebUrl = repo.WebUrl,
                         Deleted = repo.Deleted,
-                        LastCommitId = repo.LastCommitId
+                        LastCommitId = repo.LastCommitId,
+                        NoScan = repo.NoScan                        
                     };
 
-                    project.AddRepository(repository);
+                    dataProject.AddRepository(repository);
                 }
 
-                organization.AddProject(project);
+                organization.AddProject(dataProject);
             }
 
             return organization;

--- a/IT.TFM/ProjectScannerSaveToSqlServer/Save.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/Save.cs
@@ -127,7 +127,7 @@ namespace ProjectScannerSaveToSqlServer
             dbRepo.Deleted = repository.Deleted;
             dbRepo.LastCommitId = repository.LastCommitId;
 
-            // remove all the tildes and carrrots in spreadsheet
+            // remove all the tildes and carets in spreadsheet
 
             // This code was added here as there are a few different calls into here and this processing should most likely be done for all of them.
             // Most of the repos are named as such "[Portfolio Name]-[Project Name]-[Component Name]", The projects with a first token of "zzz" are obsolete so skip if found

--- a/IT.TFM/RepoScan.Storage.SqlServer/RepoList.cs
+++ b/IT.TFM/RepoScan.Storage.SqlServer/RepoList.cs
@@ -52,6 +52,7 @@ namespace RepoScan.Storage.SqlServer
                             ProjectUrl = project.Url,
                             ProjectVisibility = project.Visibility,
                             ProjectIsDeleted = project.Deleted,
+                            ProjectNoScan = project.NoScan,
 
                             RepositoryDefaultBranch = repo.DefaultBranch,
                             RepositoryId = repo.Id,
@@ -63,7 +64,8 @@ namespace RepoScan.Storage.SqlServer
                             RepositoryUrl = repo.Url,
                             RepositoryWebUrl = repo.WebUrl,
                             IsDeleted = repo.Deleted,
-                            RepositoryLastCommitId = repo.LastCommitId
+                            RepositoryLastCommitId = repo.LastCommitId,
+                            RepositoryNoScan = repo.NoScan
                         };
 
                         yield return item;
@@ -78,28 +80,31 @@ namespace RepoScan.Storage.SqlServer
 
         #region IWriteRepoList Implementation
 
-        void IWriteRepoList.Write(RepositoryItem item)
+        void IWriteRepoList.Write(RepositoryItem item, bool repoOnly)
         {
             var writer = GetWriter();
 
-            var organization = new Organization(item.Source, item.OrgName, item.OrgUrl);
-            writer.SaveOrganization(organization);
-
-            var project = new Project()
+            if (!repoOnly)
             {
-                Id = item.ProjectId,
-                Url = item.ProjectUrl,
-                Abbreviation = item.ProjectAbbreviation,
-                Description = item.ProjectDescription,
-                LastUpdate = item.ProjectLastUpdate,
-                Name = item.ProjectName,
-                Revision = item.ProjectRevision,
-                State = item.ProjectState,
-                Visibility = item.ProjectVisibility,
-                Deleted = item.ProjectIsDeleted,
-            };
+                var organization = new Organization(item.Source, item.OrgName, item.OrgUrl);
+                writer.SaveOrganization(organization);
 
-            writer.SaveProject(project);
+                var project = new Project()
+                {
+                    Id = item.ProjectId,
+                    Url = item.ProjectUrl,
+                    Abbreviation = item.ProjectAbbreviation,
+                    Description = item.ProjectDescription,
+                    LastUpdate = item.ProjectLastUpdate,
+                    Name = item.ProjectName,
+                    Revision = item.ProjectRevision,
+                    State = item.ProjectState,
+                    Visibility = item.ProjectVisibility,
+                    Deleted = item.ProjectIsDeleted
+                };
+
+                writer.SaveProject(project);
+            }
 
             var repository = new Repository
             {


### PR DESCRIPTION
Adding a flag called NoScan to the Projects and Repositories tables. These are set manually, and indicate that these do not need to be scanned.

Also did a few tweaks to skip the writing of Org and Projects more than once in certain cases.