### PR TITLE
Bug Fix, causing build error

### DIFF
--- a/IT.TFM/AzureDevOpsScannerFramework/Scanner.cs
+++ b/IT.TFM/AzureDevOpsScannerFramework/Scanner.cs
@@ -32,7 +32,7 @@ namespace AzureDevOpsScannerFramework
 
         private static readonly AzureDevOps.IRestApi api = new AzureDevOps.RestApi();
 
-        private Dictionary<string, string> buildProperties = new();
+        private static readonly Dictionary<string, string> buildProperties = [];
 
         #endregion
 


### PR DESCRIPTION
Missed something and it caused a build failure. The buildProperties dictionary needs to be static. 

Sometimes VS gets a bit weird with the errors it reports - like it has some of this cached from earlier code. I had to exit and re-start VS to clear this up.