### PR TITLE
Cloud Migration and package cleanup

### DIFF
--- a/IT.TFM/AzureDevOps/AzureDevOps.csproj
+++ b/IT.TFM/AzureDevOps/AzureDevOps.csproj
@@ -11,4 +11,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ConfidentialSettings\ConfidentialSettings.csproj" />
+  </ItemGroup>
 </Project>

--- a/IT.TFM/AzureDevOps/RestApi.cs
+++ b/IT.TFM/AzureDevOps/RestApi.cs
@@ -92,7 +92,7 @@ namespace AzureDevOps
                 CheckoutDirectory = Path.Combine(Environment.CurrentDirectory, Organization);
             }
 
-            Token = Environment.GetEnvironmentVariable("TFM_AdToken") ?? string.Empty;
+            Token = ConfidentialSettings.Values.Token;
         }
 
         async Task<AzDoProjectList> IRestApi.GetProjectsAsync()

--- a/IT.TFM/AzureDevOpsScannerFramework/AzureDevOpsScannerFramework.csproj
+++ b/IT.TFM/AzureDevOpsScannerFramework/AzureDevOpsScannerFramework.csproj
@@ -32,7 +32,9 @@
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/IT.TFM/AzureDevOpsScannerFramework/Scanner.cs
+++ b/IT.TFM/AzureDevOpsScannerFramework/Scanner.cs
@@ -32,7 +32,7 @@ namespace AzureDevOpsScannerFramework
 
         private static readonly AzureDevOps.IRestApi api = new AzureDevOps.RestApi();
 
-        private Dictionary<string, string> buildProperties = new();
+        private static readonly Dictionary<string, string> buildProperties = [];
 
         #endregion
 

--- a/IT.TFM/ConfidentialSettings/ConfidentialSettings.csproj
+++ b/IT.TFM/ConfidentialSettings/ConfidentialSettings.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/IT.TFM/ConfidentialSettings/Values.cs
+++ b/IT.TFM/ConfidentialSettings/Values.cs
@@ -1,0 +1,42 @@
+﻿namespace ConfidentialSettings
+{
+    public static class Values
+    {
+        #region Private Members
+
+        private const string envToken = "TFM_AdToken";
+
+        private const string envOrg = "TFM_ScannerName";
+
+        private const string envUrl = "TFM_ScannerValue";
+
+        private const string envDbConnection = "TFM_DbConnection";
+
+        #endregion
+
+        #region Constructors
+
+        static Values()
+        {
+            Token = Environment.GetEnvironmentVariable(envToken) ?? string.Empty;
+            Organization = Environment.GetEnvironmentVariable(envOrg) ?? string.Empty;
+            OrganizationUrl = Environment.GetEnvironmentVariable(envUrl) ?? string.Empty;
+            DbConnection = Environment.GetEnvironmentVariable(envDbConnection) ?? string.Empty;
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        public static string Token { get; private set; } = string.Empty;
+
+        public static string Organization { get; private set; } = string.Empty;
+
+        public static string OrganizationUrl { get; private set; } = string.Empty;
+
+        public static string DbConnection { get; private set; } = string.Empty;
+
+        #endregion
+
+    }
+}

--- a/IT.TFM/ConfidentialSettings/Values.cs
+++ b/IT.TFM/ConfidentialSettings/Values.cs
@@ -4,13 +4,13 @@
     {
         #region Private Members
 
-        private const string envToken = "TFM_AdToken";
+        private const string envToken = "azdo-pat";
 
-        private const string envOrg = "TFM_ScannerName";
+        private const string envOrg = "azdo-org-name";
 
-        private const string envUrl = "TFM_ScannerValue";
+        private const string envUrl = "azdo-org-url";
 
-        private const string envDbConnection = "TFM_DbConnection";
+        private const string envDbConnection = "sql-connectionstring";
 
         #endregion
 

--- a/IT.TFM/Parser/ParseXmlFile.cs
+++ b/IT.TFM/Parser/ParseXmlFile.cs
@@ -3,7 +3,10 @@ using ProjectData;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Xml;
+
+using Unity.Builder;
 
 namespace Parser
 {
@@ -141,10 +144,32 @@ namespace Parser
             foreach (XmlNode node in nodeList)
             {
                 var attribute = node.Attributes[xmlAttrInclude]?.Value;
+                string versionAttribute = string.Empty;
+
                 if (ValidReference(attribute))
                 {
-                    var versionAttribute = node.Attributes[xmlAttrPkgVersion]?.Value;
-                    if (versionAttribute.StartsWith("$"))
+                    foreach (XmlAttribute attributeValue in node.Attributes)
+                    {                         
+                        if (attributeValue.Name.Equals(xmlAttrPkgVersion, System.StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            versionAttribute = node.Attributes[xmlAttrPkgVersion]?.Value;
+                            break;
+                        }
+                    }
+
+                    if (string.IsNullOrEmpty(versionAttribute))
+                    {
+                        versionAttribute = string.Empty;
+                        foreach (XmlNode childNode in node.ChildNodes)
+                        {
+                            if (childNode.Name.Equals("Version", System.StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                versionAttribute = childNode.InnerText;
+                                break;
+                            }
+                        }
+                    }
+                    else if (versionAttribute.StartsWith("$"))
                     {
                         versionAttribute = versionAttribute.Replace("$(", string.Empty).Replace(")", string.Empty);
                         // find the entry from the Directory.Build.props file - if not found then leave this blank.

--- a/IT.TFM/ProjectScanner.sln
+++ b/IT.TFM/ProjectScanner.sln
@@ -62,6 +62,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NpmFileParser", "NpmFilePar
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AzureDevOps", "AzureDevOps\AzureDevOps.csproj", "{58D2CEAF-71D0-422E-9FD2-6C702C0320EF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfidentialSettings", "ConfidentialSettings\ConfidentialSettings.csproj", "{2CEBFB57-78AF-46FC-977B-626DAF7C3619}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -154,6 +156,10 @@ Global
 		{58D2CEAF-71D0-422E-9FD2-6C702C0320EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{58D2CEAF-71D0-422E-9FD2-6C702C0320EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{58D2CEAF-71D0-422E-9FD2-6C702C0320EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CEBFB57-78AF-46FC-977B-626DAF7C3619}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CEBFB57-78AF-46FC-977B-626DAF7C3619}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CEBFB57-78AF-46FC-977B-626DAF7C3619}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CEBFB57-78AF-46FC-977B-626DAF7C3619}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -182,6 +188,7 @@ Global
 		{EA62A644-2C15-4735-A6E4-5021F0EB2A9F} = {DAB4B476-8AFA-4AE7-9737-0FA45B6F55C1}
 		{F2F7A77A-888B-47ED-B22D-69B6CB85B130} = {DAB4B476-8AFA-4AE7-9737-0FA45B6F55C1}
 		{58D2CEAF-71D0-422E-9FD2-6C702C0320EF} = {10E88914-F313-43A5-9893-24F5D79F51CB}
+		{2CEBFB57-78AF-46FC-977B-626DAF7C3619} = {AE122355-12E2-4890-8041-3B2B307CDDFB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {13E06812-4F34-4E3C-8E19-5A26F31CF9C8}

--- a/IT.TFM/ProjectScannerFramework/ProjectScanner.csproj
+++ b/IT.TFM/ProjectScannerFramework/ProjectScanner.csproj
@@ -10,6 +10,7 @@
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\ConfidentialSettings\ConfidentialSettings.csproj" />
     <ProjectReference Include="..\Parser\Parser.csproj" />
     <ProjectReference Include="..\ProjectDataFramework\ProjectData.csproj" />
   </ItemGroup>

--- a/IT.TFM/ProjectScannerFramework/Settings.cs
+++ b/IT.TFM/ProjectScannerFramework/Settings.cs
@@ -72,11 +72,11 @@ namespace ProjectScanner
             {
                 if (!IsInitialized)
                 {
-                    var envScanner = Environment.GetEnvironmentVariable("TFM_ScannerName");
-                    var envScannerValue = Environment.GetEnvironmentVariable("TFM_ScannerValue");
-                    scanners = new Dictionary<string, string>();
+                    var envScanner = ConfidentialSettings.Values.Organization;
+                    var envScannerValue = ConfidentialSettings.Values.OrganizationUrl;
+                    scanners = [];
 
-                    if (envScanner == null || envScannerValue == null)
+                    if (string.IsNullOrEmpty(envScanner) || string.IsNullOrEmpty(envScannerValue))
                     {
                         var appSettings = ConfigurationManager.AppSettings;
 

--- a/IT.TFM/ProjectScannerSaveToSqlServer/Save.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/Save.cs
@@ -469,8 +469,10 @@ namespace ProjectScannerSaveToSqlServer
             // Next update any of the existing database properties that are in the list
             foreach (var dbRef in dbReferences)
             {
-                var reference = references.SingleOrDefault(r => r.PackageType.Equals(dbRef.PackageType, StringComparison.InvariantCultureIgnoreCase)
-                                                             && r.Id.Equals(dbRef.Name, StringComparison.InvariantCultureIgnoreCase));
+                var reference = references.Where(r => r.PackageType.Equals(dbRef.PackageType, StringComparison.InvariantCultureIgnoreCase)
+                                                   && r.Id.Equals(dbRef.Name, StringComparison.InvariantCultureIgnoreCase))
+                                          .OrderBy(r => r.Version).Last();
+
                 if (reference != null)
                 {
                     dbRef.Version = reference.Version;
@@ -482,8 +484,8 @@ namespace ProjectScannerSaveToSqlServer
             // Finally add any new properties from the list that are not in the database for this file
             foreach (var reference in references)
             {
-                var dbReference = dbReferences.SingleOrDefault(r => r.PackageType.Equals(reference.PackageType, StringComparison.InvariantCultureIgnoreCase)
-                                                                 && r.Name.Equals(reference.Id, StringComparison.InvariantCultureIgnoreCase));
+                var dbReference = dbReferences.FirstOrDefault(r => r.PackageType.Equals(reference.PackageType, StringComparison.InvariantCultureIgnoreCase)
+                                                                && r.Name.Equals(reference.Id, StringComparison.InvariantCultureIgnoreCase));
 
                 if (dbReference == null)
                 {

--- a/IT.TFM/Storage/Settings.cs
+++ b/IT.TFM/Storage/Settings.cs
@@ -22,8 +22,8 @@ namespace Storage
             var appSettings = ConfigurationManager.AppSettings;
             Storage = appSettings[storageKey];
 
-            var dbConfiguration = Environment.GetEnvironmentVariable("TFM_DbConnection");
-            if (dbConfiguration == null)
+            var dbConfiguration = ConfidentialSettings.Values.DbConnection;
+            if (string.IsNullOrEmpty(dbConfiguration))
             {
                 Configuration = $"name={appSettings[configurationKey]}";
             }

--- a/IT.TFM/Storage/Storage.csproj
+++ b/IT.TFM/Storage/Storage.csproj
@@ -10,6 +10,7 @@
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\ConfidentialSettings\ConfidentialSettings.csproj" />
     <ProjectReference Include="..\ProjectDataFramework\ProjectData.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/IT.TFM/TfmScanWithToken/App.config
+++ b/IT.TFM/TfmScanWithToken/App.config
@@ -24,7 +24,7 @@
 		<add key="processingThreads" value="8"/>
 		<add key="Scanner||ORG_NAME_PLACEHOLDER" value="AzureDevOps||ORG_URL_PLACEHOLDER" />
 		<add key="useFileFiltering" value="false" />
-		<add key="forceDetails" value="true"/>
+		<add key="forceDetails" value="false"/>
 
 		<add key="StorageType" value="SqlServerStorage" />
 		<add key="StorageConfiguration" value="ProjectScannerDB" />

--- a/IT.TFM/TfmScanWithToken/App.config
+++ b/IT.TFM/TfmScanWithToken/App.config
@@ -24,7 +24,7 @@
 		<add key="processingThreads" value="8"/>
 		<add key="Scanner||ORG_NAME_PLACEHOLDER" value="AzureDevOps||ORG_URL_PLACEHOLDER" />
 		<add key="useFileFiltering" value="false" />
-		<add key="forceDetails" value="false"/>
+		<add key="forceDetails" value="true"/>
 
 		<add key="StorageType" value="SqlServerStorage" />
 		<add key="StorageConfiguration" value="ProjectScannerDB" />


### PR DESCRIPTION
First, this introduces a new ConfidentialSettings class, which is used to read and cache the secret values loaded from the Key Vault.  These values override anything found in the app.config file. If these secret values are missing, will revert back to reading the app.config file.

There were also some significant changes in how package references are read from a .Net project file, specifically in how the version is specified.  The version could either be an attribute or a child node of the PackageReference include node for a package. Also it needed to be case-insensitive. This has been resolved. However, there are also much older "Reference" nodes in a project file that also needs to be addressed, so that we have a single dataset for all packages with versions.

Also had a single build issue around the buildProperty dictionary that I introduced, not sure how I missed that.