### PR TITLE
Updating System.Data.SqlClient to 4.8.6 to eliminate minor vulnerability

### DIFF
--- a/IT.TFM/AzureDevOpsScannerFramework/AzureDevOpsScannerFramework.csproj
+++ b/IT.TFM/AzureDevOpsScannerFramework/AzureDevOpsScannerFramework.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.205.1" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.205.1" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />

--- a/IT.TFM/ProjectScannerSaveToSqlServer/ProjectScannerSaveToSqlServer.csproj
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/ProjectScannerSaveToSqlServer.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />


### PR DESCRIPTION
Mend was reporting a minor vulnerability, required an update of System.Data.SqlClient to 4.8.6