### PR TITLE
Conflict in multiple threads over shared data

### DIFF
--- a/IT.TFM/FileLocator/PipelineScanner.cs
+++ b/IT.TFM/FileLocator/PipelineScanner.cs
@@ -104,7 +104,7 @@ namespace RepoScan.FileLocator
 
         #region Private Methods
 
-        public static void LinkYamlPipeline(string repositoryId, string filePath)
+        private static void LinkYamlPipeline(string repositoryId, string filePath)
         {
             lock (pipelineReaderLock)
             {

--- a/IT.TFM/ProjectScannerSaveToSqlServer/Read.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/Read.cs
@@ -376,6 +376,8 @@ namespace ProjectScannerSaveToSqlServer
                 throw new ArgumentOutOfRangeException(nameof(pipelineType), $"Invalid pipeline type specified ({pipelineType}). Must be one of ({Pipeline.pipelineTypeYaml}, {Pipeline.pipelineTypeClassic}).");
             }
 
+            var pipelineList = new List<Pipeline>();
+
             context.Database.CommandTimeout = 300;
             var pipelines = context.Pipelines.Where(p => p.Type == pipelineType);
             foreach (var dbPipeline in pipelines)
@@ -397,8 +399,10 @@ namespace ProjectScannerSaveToSqlServer
                     FileId = file?.FileId
                 };
 
-                yield return pipeline;
+                pipelineList.Add(pipeline);
             }
+
+            return pipelineList.AsEnumerable();
         }
 
         public IEnumerable<Pipeline> GetPipelines(string repositoryId, string filePath)


### PR DESCRIPTION
When using multiple threads, having the shared data of pipelines is failing because of the yield statement. Removed that so the entire data set is returned and available immediately for all threads.

Also made the LinkYamlPipeline method private, as it should not be exposed externally

NOTE: I have no idea why all the diffs got into there, seems like a whitespace issue. Check lines 302-406 in the second file