### PR TITLE
Making some tweaks to the supporting tasks for the TFM scan:

### DIFF
--- a/IT.TFM/ReportsRefresh/Program.cs
+++ b/IT.TFM/ReportsRefresh/Program.cs
@@ -1,9 +1,11 @@
 using System.Data;
 using System.Data.SqlClient;
 
-const int sqlExecuteTimeout = 600;  // 600 seconds = 10 minutes
+const int sqlExecuteTimeout = 3600;  // 3600 seconds = 30 minutes
 const string sqlUpdate = "dbo.UpdateReports";
 const string sqlCleanup = "dbo.CleanupReports";
+const string sqlEmptyAITable = "TRUNCATE TABLE [dbo].[AIQueryTable]";
+const string sqlFillAITable = "EXECUTE [AI].[Refresh]";
 const string sqlDaysParameter = "@days";
 
 if (args.Length == 0)
@@ -22,12 +24,20 @@ switch (args[0])
     case "c":
         if (args.Length < 2 || !int.TryParse(args[1], out var value))
         {
-            throw new ArgumentException("For cleanup, you need to specify a second int parameter indicating number of days to maintain. Ex: c 30");
+            throw new ArgumentException("For cleanup, you need to specify a second integer parameter indicating number of days to maintain. Ex: c 30");
         }
         Cleanup(connectionString, value);
         return;
 
-    default: throw new ArgumentException("Invalid argument given, must be either u for update, or c for cleanup");
+    case "ax":
+        EmptyAIQuery(connectionString);
+        return;
+
+    case "af":
+        FillAIQuery(connectionString);
+        return;
+
+    default: throw new ArgumentException("Invalid argument given, must be either u for update, c for cleanup, ax for cleanup AI query table, or af to fill the AI query table");
 }
 
 void Update(string connectionString)
@@ -53,6 +63,32 @@ void Cleanup(string connectionString, int days)
     };
     var daysParameter = command.Parameters.Add(sqlDaysParameter, SqlDbType.Int);
     daysParameter.Value = days;
+
+    command.Connection.Open();
+    command.ExecuteNonQuery();
+}
+
+void EmptyAIQuery(string connectionString)
+{
+    using SqlConnection connection = new(connectionString);
+    var command = new SqlCommand(sqlEmptyAITable, connection)
+    {
+        CommandType = CommandType.Text,
+        CommandTimeout = sqlExecuteTimeout
+    };
+
+    command.Connection.Open();
+    command.ExecuteNonQuery();
+}
+
+void FillAIQuery(string connectionString)
+{
+    using SqlConnection connection = new(connectionString);
+    var command = new SqlCommand(sqlFillAITable, connection)
+    {
+        CommandType = CommandType.Text,
+        CommandTimeout = sqlExecuteTimeout
+    };
 
     command.Connection.Open();
     command.ExecuteNonQuery();


### PR DESCRIPTION
- changing the SQL Execute timeout from 10 minutes to 30 minutes. Some of the these tasks take more than 10 minutes to process on a single SQL: connection
- Adding tasks to clean up and refresh the AI Query Table.