### PR TITLE
When deleting a file, ensure that the ProjectMetrics are also deleted.

### DIFF
--- a/IT.TFM/ProjectScannerSaveToSqlServer/Save.cs
+++ b/IT.TFM/ProjectScannerSaveToSqlServer/Save.cs
@@ -440,6 +440,11 @@ namespace ProjectScannerSaveToSqlServer
                 pipeline.FileId = null;
             }
 
+            if (dbFile.ProjectMetrics != null)
+            {
+                context.ProjectMetrics.Remove(dbFile.ProjectMetrics);
+            }
+
             _ = context.SaveChangesAsync().Result;
 
             context.Files.Remove(dbFile);


### PR DESCRIPTION
Fixed issue when deleting files referenced by an entry in ProjectMetrics. Need to ensure that the ProjectMetrics entry is deleted first.

The only changes are lines 443-446. For some reason after re-installing VS, the end of line character changed with just mucked up the file.