### PR TITLE
Adding fix to use the values for portfolio and/or product if not found otherwise

### DIFF
--- a/IT.TFM/YamlFileParser/PipelineParser.cs
+++ b/IT.TFM/YamlFileParser/PipelineParser.cs
@@ -48,6 +48,20 @@ namespace YamlFileParser
                     {
                         ParseV1Template(cleanContent, variables, file);
                     }
+
+                    // If portfolio and product are still empty, see if any of the variables match.
+                    if (file.PipelineProperties["portfolio"] == string.Empty && file.PipelineProperties["product"] == string.Empty)
+                    {
+                        if (variables.TryGetValue("portfolioName", out var portfolio))
+                        {
+                            file.PipelineProperties["portfolio"] = portfolio;
+                        }
+
+                        if (variables.TryGetValue("productName", out var product))
+                        {
+                            file.PipelineProperties["product"] = product;
+                        }
+                    }
                     break;
             }
         }


### PR DESCRIPTION
This seems to be a typical issue for pipelines using the Generic templates, making it difficult to find the places in the YAML code where the portfolio and product values are set as parameters. However, I have the variables section already parsed from the code. In the case where the portfolio and/or product name is not found normally, I will use the explicit values of the portfolioName and productName variables if they are in the variables list.