### PR TITLE
Rename envToken constant to match documentation

### DIFF
--- a/IT.TFM/ConfidentialSettings/Values.cs
+++ b/IT.TFM/ConfidentialSettings/Values.cs
@@ -4,7 +4,7 @@
     {
         #region Private Members
 
-        private const string envToken = "azdo-pat";
+        private const string envToken = "TFM_AdToken";
 
         private const string envOrg = "azdo-org-name";
 


### PR DESCRIPTION
In the set up document this is called 'TFM_AdToken', so updating the Values file to correspond to this properly, otherwise the application will not run, without a valid PAT.